### PR TITLE
Smartlogic adaptations for JenaDatabaseClient

### DIFF
--- a/marklogic-jena/src/main/java/com/marklogic/semantics/jena/client/JenaDatabaseClient.java
+++ b/marklogic-jena/src/main/java/com/marklogic/semantics/jena/client/JenaDatabaseClient.java
@@ -24,6 +24,7 @@ import org.apache.jena.riot.WriterGraphRIOT;
 
 import com.hp.hpl.jena.graph.Graph;
 import com.hp.hpl.jena.graph.Node;
+import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.query.ReadWrite;
 import com.hp.hpl.jena.sparql.graph.GraphFactory;
 import com.marklogic.client.DatabaseClient;
@@ -57,21 +58,31 @@ public class JenaDatabaseClient {
      * @param client a Java Client API DatabaseClient.  Can be made with com.marklogic.client.DatabaseClientFactory
      */
     public JenaDatabaseClient(DatabaseClient client) {
+        this(client, true);
+    }
+
+    public JenaDatabaseClient(DatabaseClient client, boolean periodicFlush) {
         this.client = client;
         this.graphManager = client.newGraphManager();
         this.graphManager.setDefaultMimetype(RDFMimeTypes.NTRIPLES);
         this.sparqlQueryManager = client.newSPARQLQueryManager();
-        this.cache = new WriteCacheTimerTask(this);
-        this.timer = new Timer();
-        timer.scheduleAtFixedRate(cache, 1000, 1000);
+        if (periodicFlush) {
+            this.cache = new WriteCacheTimerTask(this);
+            this.timer = new Timer();
+            timer.scheduleAtFixedRate(cache, 1000, 1000);
+        }
     }
 
     /**
      * Close the connection and free resources
      */
     public void close() {
-        cache.cancel();
-        timer.cancel();
+        if (cache != null) {
+            cache.cancel();
+        }
+        if (timer != null) {
+            timer.cancel();
+        }
         client = null;
     }
     
@@ -186,17 +197,25 @@ public class JenaDatabaseClient {
         sender.setGraph(graph);
         OutputStreamHandle handle = new OutputStreamHandle(sender);
         this.graphManager.write(uri, handle, currentTransaction);
-    }
-
+    }    
     /**
-     * Puts a quad into the cache, which is periodically sent to MarkLogic
+     * If timer is turned on (periodicFlush = true in constructor) 
+     * this method puts a quad into the cache which is periodically sent to MarkLogic
+     * otherwise it sends the quad directly
      * @param g Graph node.
      * @param s Subject node
      * @param p Property node.
      * @param o Object Node.
      */
     public void sinkQuad(Node g, Node s, Node p, Node o) {
-        cache.add(g, s, p, o);
+        if (cache != null) {
+            cache.add(g, s, p, o);   
+        } else {
+            Graph graph = GraphFactory.createDefaultGraph();
+            graph.add(Triple.create(s,p,o));
+            mergeGraph(g.getURI(), graph);
+            return;
+        }
     }
 
     /**
@@ -204,10 +223,10 @@ public class JenaDatabaseClient {
      * before query/delete.
      */
     public void sync() {
-        cache.forceRun();
+        if (cache != null) {
+            cache.forceRun();
+        }
     }
-
-    
 
     private void checkCurrentTransaction() {
         if (this.currentTransaction == null) {
@@ -233,9 +252,12 @@ public class JenaDatabaseClient {
     }
 
     public void abort() {
-        checkCurrentTransaction();
-        this.currentTransaction.rollback();
-        this.currentTransaction = null;
+        try {
+          checkCurrentTransaction();
+          currentTransaction.rollback();
+        } finally {
+          currentTransaction = null;
+        }
     }
 
     public boolean isInTransaction() {


### PR DESCRIPTION
In this pull request we introduce two changes to JenaDatabaseClient that we found out 
necessary for our system. The changes have been tested as we use the forked version 
already in our system. Also, the changes preserve the current API of the client.

There changes are:
- an option to turn off the timer-based flushing mechanism ("periodicFlush = false", we use this option in our system, the default remains "periodicFlush = true").
- closing client transaction when currentTransaction.rollback() fails (abort() method)
