### PR TITLE
Fix handling of lang literals (in Jena 3 they have both type and lang)

### DIFF
--- a/marklogic-jena/src/main/java/com/marklogic/semantics/jena/MarkLogicDatasetGraph.java
+++ b/marklogic-jena/src/main/java/com/marklogic/semantics/jena/MarkLogicDatasetGraph.java
@@ -143,7 +143,11 @@ public class MarkLogicDatasetGraph extends DatasetGraphTriplesQuads implements
         if (objectNode.isURI()) {
             bindings.bind(variableName, objectNode.getURI());
         } else if (objectNode.isLiteral()) {
-            if (objectNode.getLiteralDatatype() != null) {
+            if (! "".equals(objectNode.getLiteralLanguage())) {
+              String languageTag = objectNode.getLiteralLanguage();
+              bindings.bind(variableName, objectNode.getLiteralLexicalForm(),
+                      Locale.forLanguageTag(languageTag));
+            } else if (objectNode.getLiteralDatatype() != null) {
                 try {
                     String xsdType = objectNode.getLiteralDatatypeURI();
                     String fragment = new URI(xsdType).getFragment();
@@ -155,10 +159,6 @@ public class MarkLogicDatasetGraph extends DatasetGraphTriplesQuads implements
                     throw new MarkLogicJenaException(
                             "Unrecognized binding type.  Use XSD only.", e);
                 }
-            } else if (! "".equals(objectNode.getLiteralLanguage())) {
-                String languageTag = objectNode.getLiteralLanguage();
-                bindings.bind(variableName, objectNode.getLiteralLexicalForm(),
-                        Locale.forLanguageTag(languageTag));
             } else {
                 // is this a hole, no type string?
                 bindings.bind(variableName, objectNode.getLiteralLexicalForm(),

--- a/marklogic-jena/src/test/java/com/marklogic/semantics/jena/MarkLogicDatasetGraphTest.java
+++ b/marklogic-jena/src/test/java/com/marklogic/semantics/jena/MarkLogicDatasetGraphTest.java
@@ -138,6 +138,22 @@ public class MarkLogicDatasetGraphTest extends JenaTestBase {
     }
 
     @Test
+    public void testFindByLiteralWithLanguage() {
+        Node g = NodeFactory.createURI("http://example.org/g");
+        Node s = NodeFactory.createURI("s");
+        Node p = NodeFactory.createURI("p");
+        Node o = NodeFactory.createLiteral("abc", "en");
+
+        DatasetGraph markLogicDatasetGraph = getMarkLogicDatasetGraph();
+        markLogicDatasetGraph.add(g, s, p, o);
+        Iterator<Quad> iter = markLogicDatasetGraph.find(g, null, null, o);
+        Quad quad = iter.next();
+
+        assertEquals("abc", quad.getObject().getLiteralLexicalForm());
+        assertEquals("en", quad.getObject().getLiteralLanguage());
+    }
+
+    @Test
     public void testQuadsView() {
 
         Node newSubject = NodeFactory.createURI("http://newSubject");


### PR DESCRIPTION
This is a fix for incorrect handling of literals with language tags.

Without the fix, when invoking MarklogicDatasetGraph.find(g, s, p, o) with an object that is a literal with language, the following error was thrown: 

`com.marklogic.client.FailedRequestException: Local message: failed to apply resource at /graphs/sparql: Bad Request. Server Message: REST-INVALIDPARAM: (err:FOER0000) Invalid parameter: Bind variable type parameter requires XSD type
    at com.marklogic.client.impl.JerseyServices.checkStatus(JerseyServices.java:4646)
    at com.marklogic.client.impl.JerseyServices.postResource(JerseyServices.java:3526)
    at com.marklogic.client.impl.JerseyServices.executeSparql(JerseyServices.java:5653)
    at com.marklogic.client.impl.SPARQLQueryManagerImpl.executeQueryImpl(SPARQLQueryManagerImpl.java:107)
    at com.marklogic.client.impl.SPARQLQueryManagerImpl.executeQueryImpl(SPARQLQueryManagerImpl.java:100)
    at com.marklogic.client.impl.SPARQLQueryManagerImpl.executeSelect(SPARQLQueryManagerImpl.java:66)
    at com.marklogic.semantics.jena.client.JenaDatabaseClient.executeSelect(JenaDatabaseClient.java:141)
    at com.marklogic.semantics.jena.client.JenaDatabaseClient.executeSelect(JenaDatabaseClient.java:148)
    at com.marklogic.semantics.jena.MarkLogicDatasetGraph.selectTriplesInGraph(MarkLogicDatasetGraph.java:274)
    at com.marklogic.semantics.jena.MarkLogicDatasetGraph.findInSpecificNamedGraph(MarkLogicDatasetGraph.java:298)
    at org.apache.jena.sparql.core.DatasetGraphBaseFind.findNG(DatasetGraphBaseFind.java:64)
    at org.apache.jena.sparql.core.DatasetGraphBaseFind.find(DatasetGraphBaseFind.java:49)`

In Jena 2 such literals did not have any type, so that the original code worked properly (in master branch).

In Jena 3 they have both the xsd:langString type AND the language tag, so the code needs to be fixed to take that into account. This fix is only need for Jena 3 version of this library (develop branch).

A related pull request was made to java-client-api, see: https://github.com/marklogic/java-client-api/pull/430
