### PR TITLE
Upgraded jena to 3.2.0

### DIFF
--- a/marklogic-jena/build.gradle
+++ b/marklogic-jena/build.gradle
@@ -10,23 +10,15 @@ version = '3.0.2-SNAPSHOT'
 group   = 'com.marklogic'
 
 dependencies {
-    compile('org.apache.jena:jena-arq:3.1.0') {
-	   exclude(group: 'org.slf4j')
-       exclude(group: 'ch.qos.logback')
-       exclude(group: 'log4j')
-    }
-    compile('com.marklogic:marklogic-client-api:4.0-SNAPSHOT') {
-	   exclude(group: 'org.slf4j')
-       exclude(group: 'ch.qos.logback')
-    }
-   
+    compile('org.apache.jena:jena-arq:3.2.0')
+    compile('com.marklogic:marklogic-client-api:4.0-SNAPSHOT')
+
 	compile("org.slf4j:slf4j-api:$slf4jVersion")
 	compile "ch.qos.logback:logback-classic:$logbackVersion"
 	compile "org.slf4j:jcl-over-slf4j:$slf4jVersion"
 
 	testCompile 'com.jayway.restassured:rest-assured:2.9.0'
 	testCompile 'org.hamcrest:hamcrest-all:1.3'
-	testCompile 'junit:junit:4.12'
 }
 
 sourceSets {

--- a/marklogic-jena/src/main/java/com/marklogic/semantics/jena/engine/MarkLogicQueryEngine.java
+++ b/marklogic-jena/src/main/java/com/marklogic/semantics/jena/engine/MarkLogicQueryEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MarkLogic Corporation
+ * Copyright 2016-2017 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-jena/src/main/java/com/marklogic/semantics/jena/engine/MarkLogicUpdateEngine.java
+++ b/marklogic-jena/src/main/java/com/marklogic/semantics/jena/engine/MarkLogicUpdateEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MarkLogic Corporation
+ * Copyright 2016-2017 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/marklogic-jena/src/main/java/com/marklogic/semantics/jena/engine/package-info.java
+++ b/marklogic-jena/src/main/java/com/marklogic/semantics/jena/engine/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the Apache License, Version 2.0 (the "License");
+ * Copyright 2016-2017 the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *


### PR DESCRIPTION
Hi @kkanthet this is a PR that simply upgrades to the latest release of jena prior to our release.  I'd like this upgrade to go into the next release of marklogic-jena, which should be immediately upon release of the next java client.