### PR TITLE
Updating dependencies and Gradle config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.java]
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ https://github.com/marklogic/marklogic-jena/tree/develop
 2) Run the gradle target that provisions a testing database for this project.  The command and tests use values recorded in `./gradle.properties`.
 
 ```
-gradle :marklogic-jena:mlDeploy
+./gradlew :marklogic-jena:mlDeploy
 ```
 
 3) Build MarkLogic Jena.
 
 ```
-gradle :marklogic-jena:test
+./gradlew :marklogic-jena:test
 
 ```
 
 To use `marklogic-jena` in your own projects, deploy into local maven repo or copy snapshot jars from /build directory.
 
 ```
-gradle install
+./gradlew publishToMavenLocal
 
 ```
 
@@ -45,7 +45,7 @@ gradle install
 For gradle-based projects include this dependency in `build.gradle`:
 ```
 dependencies {
-   compile 'com.marklogic:marklogic-jena:3.0.3'
+   implementation 'com.marklogic:marklogic-jena:3.1.0'
 }
 ```
 
@@ -55,7 +55,7 @@ Maven-based projects use this block in `pom.xml`:
 <dependency>
     <groupId>com.marklogic</groupId>
     <artifactId>marklogic-jena</artifactId>
-    <version>3.0.3</version>
+    <version>3.1.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,45 +1,30 @@
 plugins {
-    id "com.marklogic.ml-gradle" version "3.9.0"
+    id "com.marklogic.ml-gradle" version "4.3.5"
 }
 
 subprojects {
 
     apply plugin: 'java'
-    apply plugin: 'eclipse'
     apply plugin: 'jacoco'
     jacoco{toolVersion="0.8.4"}
-	
-    configure(allprojects){
-        ext.slf4jVersion = '1.7.25'
-        ext.logbackVersion = '1.2.3'
-    }
 
     repositories {
         mavenCentral()
-        mavenLocal()
-        jcenter()
     }
 
     jacocoTestReport {
         group = "Reporting"
         description = "Generate Jacoco coverage reports after running tests."
-        additionalSourceDirs = files(sourceSets.main.allJava.srcDirs)
     }
 
     dependencies {
-        testCompile group: 'junit', name: 'junit', version: '4.12'
-        testCompile 'org.apache.httpcomponents:httpclient:4.5.3'
+        testImplementation 'junit:junit:4.13.2'
+        testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     }
 
-    test{
-        testLogging{
-            events 'started','passed', 'skipped'
+    test {
+        testLogging {
+            events 'started', 'passed', 'skipped'
         }
     }
-
 }
-
-wrapper {
-    gradleVersion = '5.0'
-}
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip

--- a/marklogic-jena-examples/build.gradle
+++ b/marklogic-jena-examples/build.gradle
@@ -1,41 +1,38 @@
 plugins {
-    id 'me.champeau.gradle.jmh' version '0.1.3'
+  id 'me.champeau.gradle.jmh' version '0.5.3'
 }
 
 apply plugin: 'me.champeau.gradle.jmh'
 apply plugin: 'com.marklogic.ml-gradle'
-apply plugin: 'eclipse'
 apply plugin: 'java'
 
-
-
 dependencies {
-  compile project (':marklogic-jena')
-  compile 'org.openjdk.jmh:jmh-core:1.3.2'
-  compile 'org.openjdk.jmh:jmh-generator-annprocess:1.3.2'
+  implementation project(':marklogic-jena')
+  implementation 'org.openjdk.jmh:jmh-core:1.35'
+  implementation 'org.openjdk.jmh:jmh-generator-annprocess:1.35'
 }
 
 task runGraphExample(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'com.marklogic.jena.examples.GraphCRUDExample'
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'com.marklogic.jena.examples.GraphCRUDExample'
 }
 
 task runModelExample(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'com.marklogic.jena.examples.ModelCRUDExample'
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'com.marklogic.jena.examples.ModelCRUDExample'
 }
 
 task runRIOTExample(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'com.marklogic.jena.examples.RIOTExample'
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'com.marklogic.jena.examples.RIOTExample'
 }
 
 task runQueryExample(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'com.marklogic.jena.examples.SPARQLQueryExample'
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'com.marklogic.jena.examples.SPARQLQueryExample'
 }
 
 task runUpdateExample(type: JavaExec) {
-    classpath = sourceSets.main.runtimeClasspath
-    main = 'com.marklogic.jena.examples.SPARQLUpdateExample'
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'com.marklogic.jena.examples.SPARQLUpdateExample'
 }

--- a/marklogic-jena-functionaltests/build.gradle
+++ b/marklogic-jena-functionaltests/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-compile project (':marklogic-jena')
-compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.1'
-compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.1'
+  implementation project(':marklogic-jena')
+  implementation 'org.apache.logging.log4j:log4j-api:2.18.0'
+  implementation 'org.apache.logging.log4j:log4j-core:2.18.0'
 }

--- a/marklogic-jena-functionaltests/src/test/java/com/marklogic/jena/functionaltests/ConnectedRESTQA.java
+++ b/marklogic-jena-functionaltests/src/test/java/com/marklogic/jena/functionaltests/ConnectedRESTQA.java
@@ -40,8 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
 
-import ch.qos.logback.classic.Logger;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -52,14 +50,6 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 
 import java.net.InetAddress;
-
-
-
-//import org.json.JSONObject;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
-
 
 /**
  * @author gvaidees

--- a/marklogic-jena/build.gradle
+++ b/marklogic-jena/build.gradle
@@ -1,113 +1,101 @@
+plugins {
+  id "java-library"
+  id "maven-publish"
+  id "signing"
+}
 
 apply plugin: 'com.marklogic.ml-gradle'
-apply plugin: 'java'
-apply plugin: 'eclipse'
-apply plugin: 'maven-publish'
-apply plugin: 'maven'
 
+group = "com.marklogic"
+version = "3.1.0-SNAPSHOT"
 
-version = '3.0-SNAPSHOT'
-group   = 'com.marklogic'
+sourceCompatibility = "11"
+targetCompatibility = "11"
 
 dependencies {
-    compile('org.apache.jena:jena-arq:4.3.2')
-    compile('com.marklogic:marklogic-client-api:5.5.3')
+  api 'org.apache.jena:jena-arq:4.3.2'
+  api 'com.marklogic:marklogic-client-api:5.5.3'
 
-    compile("org.slf4j:slf4j-api:$slf4jVersion")
-    compile "ch.qos.logback:logback-classic:$logbackVersion"
-    compile "org.slf4j:jcl-over-slf4j:$slf4jVersion"
+  implementation "org.slf4j:slf4j-api:1.7.36"
+  implementation "ch.qos.logback:logback-classic:1.2.11"
+  implementation "org.slf4j:jcl-over-slf4j:1.7.36"
 
-    testCompile 'com.jayway.restassured:rest-assured:2.9.0'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
-}
-
-sourceSets {
-    test {
-        java {
-            srcDir 'src/test/resources'
-        }
-    }
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
+  testImplementation 'com.jayway.restassured:rest-assured:2.9.0'
+  testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
+  classifier = 'sources'
+  from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier "javadoc"
+  from javadoc
 }
 
 javadoc {
-    options.overview = "src/main/java/com/marklogic/semantics/jena/overview.html"
+  options.overview = "src/main/java/com/marklogic/semantics/jena/overview.html"
+}
+// Ignores warnings on params that don't have descriptions, which is a little too noisy
+javadoc.options.addStringOption('Xdoclint:none', '-quiet')
+
+
+artifacts {
+  archives javadocJar, sourcesJar
 }
 
-Node pomCustomizations = new NodeBuilder(). project {
-        name 'marklogic-jena'
-        packaging 'jar'
-        textdescription 'Adapter for using MarkLogic with the jena RDF Framework'
-        url 'https://github.com/marklogic/marklogic-jena'
-
-        scm {
-            url 'git@github.com:marklogic/marklogic-jena.git'
-                connection 'scm:git@github.com:marklogic/marklogic-jena.git'
-                developerConnection 'scm:git@github.com:marklogic/marklogic-jena.git'
-        }
-
-        licenses {
-            license {
-                name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-            }
-        }
- 
-        developers {
-            developer {
-                name 'MarkLogic'
-                    email 'java-sig@marklogic.com'
-                    organization 'MarkLogic'
-                    organizationUrl 'https://www.marklogic.com'
-            }
-            developer {
-                name 'MarkLogic Github Contributors'
-                    email 'general@developer.marklogic.com'
-                    organization 'Github Contributors'
-                    organizationUrl 'https://github.com/marklogic/marklogic-jena/graphs/contributors'
-            }
-        }
+signing {
+  sign configurations.archives
 }
 
 publishing {
   publications {
     mainJava(MavenPublication) {
-      from components.java
-        
-      pom.withXml { 
-        asNode().append(pomCustomizations.developers)
-        asNode().append(pomCustomizations.name)
-        asNode().append(pomCustomizations.packaging)
-        asNode().append(pomCustomizations.url)
-        asNode().append(pomCustomizations.scm)
-        asNode().append(pomCustomizations.licenses)
-        asNode().appendNode("description", pomCustomizations.textdescription.text())
+      pom {
+        name = "${group}:${project.name}"
+        description = "Adapter for using MarkLogic with the jena RDF Framework"
+        packaging = "jar"
+        url = "https://github.com/marklogic/${project.name}"
+        licenses {
+          license {
+            name = "The Apache License, Version 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+          }
+        }
+        developers {
+          developer {
+            name = 'MarkLogic'
+            email = 'java-sig@marklogic.com'
+            organization = 'MarkLogic'
+            organizationUrl = 'https://www.marklogic.com'
+          }
+          developer {
+            name = 'MarkLogic Github Contributors'
+            email = 'general@developer.marklogic.com'
+            organization = 'Github Contributors'
+            organizationUrl = 'https://github.com/marklogic/marklogic-jena/graphs/contributors'
+          }
+        }
+        scm {
+          url = "git@github.com:marklogic/${project.name}.git"
+          connection = "scm:git@github.com:marklogic/${project.name}.git"
+          developerConnection = "scm:git@github.com:marklogic/${project.name}.git"
+        }
       }
-
-      artifact sourcesJar 
-
-      artifact javadocJar 
-
+      from components.java
+      artifact sourcesJar
+      artifact javadocJar
     }
   }
   repositories {
     maven {
-      if ( project.hasProperty("mavenUser")) { 
-        credentials {
-          username mavenUser
-          password mavenPassword
-        }
+      name = "central"
+      url = mavenCentralUrl
+      credentials {
+        username mavenCentralUsername
+        password mavenCentralPassword
       }
-      url publishUrl
     }
   }
 }

--- a/marklogic-jena/gradle.properties
+++ b/marklogic-jena/gradle.properties
@@ -1,7 +1,14 @@
 group=com.marklogic
 version=3.0-SNAPSHOT
 
-publishUrl=file:../marklogic-java/releases
+# Define these on the command line to publish to OSSRH
+# See https://central.sonatype.org/publish/publish-gradle/#credentials for more information
+mavenCentralUsername=
+mavenCentralPassword=
+mavenCentralUrl=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+#signing.keyId=YourKeyId
+#signing.password=YourPublicKeyPassword
+#signing.secretKeyRingFile=PathToYourKeyRingFile
 
 mlConfigPath=marklogic-jena/src/test/ml-config
 mlHost=localhost
@@ -16,5 +23,5 @@ readerPassword=x
 validUser=j-rest-writer
 validPassword=x
 mlAppName=marklogic-jena-test
-mlRestPort=8922
+mlRestPort=8014
 


### PR DESCRIPTION
- Now using Gradle 7.5.1, which requires the use of api/implementation/testImplementation instead of the now-removed compile/testCompile
- Added .editorconfig from kafka-connector project
- Replaced config for Maven publishing with the standard config from projects like ml-javaclient-util
- Compiling against Java 11 since Jena 4.x requires Java 11
- Bumped version to 3.1.0-SNAPSHOT in anticipation of next release being 3.1.0, though we may go to 4.0 to match the Jena version

Verified that all tests pass and jacocoTestReport works as well. 